### PR TITLE
Created order_entry_transactions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ connection = SageIntacctSDK(
     user_password='<YOUR USER PASSWORD>'
 )
 ```
-2. After that you'll be able to access any of the 26 API classes: accounts, ap_payments, ar_invoices, attachments, bills, charge_card_accounts, charge_card_transactions, checking_accounts, classes, contacts, customers, departments, employees, expense_payment_types, expense_reports, expense_types, gl_detail, items, locations, projects, reimbursements, revenue_recognition_schedules, revenue_recognition_schedule_entries, savings_accounts, tasks and vendors.
+2. After that you'll be able to access any of the 27 API classes: accounts, ap_payments, ar_invoices, attachments, bills, charge_card_accounts, charge_card_transactions, checking_accounts, classes, contacts, customers, departments, employees, expense_payment_types, expense_reports, expense_types, gl_detail, items, locations, order_entry_transactions, projects, reimbursements, revenue_recognition_schedules, revenue_recognition_schedule_entries, savings_accounts, tasks and vendors.
 ```python
 """
 USAGE: <SageIntacctSDK INSTANCE>.<API_NAME>.<API_METHOD>(<PARAMETERS>)

--- a/sageintacctsdk/apis/__init__.py
+++ b/sageintacctsdk/apis/__init__.py
@@ -34,6 +34,7 @@ from .journal_entries import JournalEntries
 from .revenue_recognition_schedules import RevRecSchedules
 from .revenue_recognition_schedule_entries import RevRecScheduleEntries
 from .cost_types import CostTypes
+from .order_entry_transactions import OrderEntryTransactions
 
 __all__ = [
     'ApiBase',
@@ -68,5 +69,6 @@ __all__ = [
     'JournalEntries',
     'RevRecSchedules',
     'RevRecScheduleEntries',
-    'CostTypes'
+    'CostTypes',
+    'OrderEntryTransactions',
 ]

--- a/sageintacctsdk/apis/api_base.py
+++ b/sageintacctsdk/apis/api_base.py
@@ -291,10 +291,10 @@ class ApiBase:
         return response['result']
 
     def post(self, data: Dict):
-        if self.__dimension in ('CCTRANSACTION', 'EPPAYMENT'):
+        if self.__post_legacy_method is not None:
             return self.__construct_post_legacy_payload(data)
-
-        return self.__construct_post_payload(data)
+        else:
+            return self.__construct_post_payload(data)
 
     def update(self, data: Dict):
         '''

--- a/sageintacctsdk/apis/ar_invoices.py
+++ b/sageintacctsdk/apis/ar_invoices.py
@@ -8,4 +8,4 @@ from .api_base import ApiBase
 class ARInvoices(ApiBase):
     """Class for AR Invoice APIs."""
     def __init__(self):
-        ApiBase.__init__(self, dimension='ARINVOICE', post_legacy_method='create_invoice')
+        ApiBase.__init__(self, dimension='ARINVOICE')

--- a/sageintacctsdk/apis/gl_detail.py
+++ b/sageintacctsdk/apis/gl_detail.py
@@ -9,4 +9,4 @@ from .api_base import ApiBase
 class GLDetail(ApiBase):
     """Class for GL Detail APIs."""
     def __init__(self):
-        ApiBase.__init__(self, dimension='GLDETAIL')
+        ApiBase.__init__(self, dimension='GLDETAIL', post_legacy_method='create_sotransaction')

--- a/sageintacctsdk/apis/gl_detail.py
+++ b/sageintacctsdk/apis/gl_detail.py
@@ -9,4 +9,4 @@ from .api_base import ApiBase
 class GLDetail(ApiBase):
     """Class for GL Detail APIs."""
     def __init__(self):
-        ApiBase.__init__(self, dimension='GLDETAIL', post_legacy_method='create_sotransaction')
+        ApiBase.__init__(self, dimension='GLDETAIL')

--- a/sageintacctsdk/apis/order_entry_transactions.py
+++ b/sageintacctsdk/apis/order_entry_transactions.py
@@ -1,0 +1,10 @@
+"""
+Sage Intacct Order Entry Transactions
+"""
+from .api_base import ApiBase
+
+
+class OrderEntryTransactions(ApiBase):
+    """Class for Order Entry Transactions APIs."""
+    def __init__(self):
+        ApiBase.__init__(self, dimension='SODOCUMENT', post_legacy_method='create_sotransaction')

--- a/sageintacctsdk/sageintacctsdk.py
+++ b/sageintacctsdk/sageintacctsdk.py
@@ -5,7 +5,7 @@ from .apis import ApiBase, Contacts, Locations, Employees, Accounts, ExpenseType
     Vendors, Bills, Projects, Departments, ChargeCardAccounts, ChargeCardTransactions, Customers, Items,\
     APPayments, Reimbursements, CheckingAccounts, SavingsAccounts, Tasks, ExpensePaymentTypes, Dimensions,\
     DimensionValues, LocationEntities, ARInvoices, TaxDetails, GLDetail, Classes, JournalEntries,\
-    RevRecSchedules, RevRecScheduleEntries, CostTypes
+    RevRecSchedules, RevRecScheduleEntries, CostTypes, OrderEntryTransactions
 
 
 class SageIntacctSDK:
@@ -65,6 +65,7 @@ class SageIntacctSDK:
         self.rev_rec_schedules = RevRecSchedules()
         self.rev_rec_schedule_entries = RevRecScheduleEntries()
         self.cost_types = CostTypes()
+        self.order_entry_transactions = OrderEntryTransactions()
         self.update_sender_id()
         self.update_sender_password()
         self.update_session_id()
@@ -106,6 +107,7 @@ class SageIntacctSDK:
         self.rev_rec_schedules.set_sender_id(self.__sender_id)
         self.rev_rec_schedule_entries.set_sender_id(self.__sender_id)
         self.cost_types.set_sender_id(self.__sender_id)
+        self.order_entry_transactions.set_sender_id(self.__sender_id)
 
     def update_sender_password(self):
         """
@@ -144,6 +146,7 @@ class SageIntacctSDK:
         self.rev_rec_schedules.set_sender_password(self.__sender_password)
         self.rev_rec_schedule_entries.set_sender_password(self.__sender_password)
         self.cost_types.set_sender_password(self.__sender_password)
+        self.order_entry_transactions.set_sender_password(self.__sender_password)
 
     def update_session_id(self):
         """
@@ -184,3 +187,4 @@ class SageIntacctSDK:
         self.rev_rec_schedules.set_session_id(self.__session_id)
         self.rev_rec_schedule_entries.set_session_id(self.__session_id)
         self.cost_types.set_session_id(self.__session_id)
+        self.order_entry_transactions.set_session_id(self.__session_id)


### PR DESCRIPTION
I just tested and this works to post ~GL Detail~ Order Entry Transaction data to the Intacct API. ~Resolves #48.~

~Added post_legacy_method for GLDetails.~

I also slightly changed the logic that determines whether to use the legacy method or not in the post. Rather than checking whether a dimension is in a hard-coded list (which feels to me to be against object-oriented programming principles anyway), post() now checks whether a legacy method is defined. If it is, it is used, otherwise the default payload is constructed.

I also removed the post_legacy_method from ARInvoices because it was not in the hard-coded list, so the legacy method was almost certainly not called anyway.