### PR TITLE
Adding functionality to delete attachments

### DIFF
--- a/sageintacctsdk/apis/attachments.py
+++ b/sageintacctsdk/apis/attachments.py
@@ -50,7 +50,7 @@ class Attachments(ApiBase):
         """
         data = {
             'delete_supdoc': {
-                "key": key
+                '@key': key
                 }
         }
         return self.format_and_send_request(data)

--- a/sageintacctsdk/apis/attachments.py
+++ b/sageintacctsdk/apis/attachments.py
@@ -43,7 +43,7 @@ class Attachments(ApiBase):
         return self.format_and_send_request(data)
 
     def delete(self, key: str):
-        """Delete attachments in Sage Intacct.
+        """Delete a attachment in Sage Intacct.
 
         Returns:
             Dict of state of request

--- a/sageintacctsdk/apis/attachments.py
+++ b/sageintacctsdk/apis/attachments.py
@@ -42,6 +42,19 @@ class Attachments(ApiBase):
         }
         return self.format_and_send_request(data)
 
+    def delete(self, key: str):
+        """Delete attachments in Sage Intacct.
+
+        Returns:
+            Dict of state of request
+        """
+        data = {
+            'delete_supdoc': {
+                "key": key
+                }
+        }
+        return self.format_and_send_request(data)
+
     def get_folder(self, field: str, value: str):
         """Get attachment folder from Sage Intacct
 

--- a/sageintacctsdk/apis/attachments.py
+++ b/sageintacctsdk/apis/attachments.py
@@ -43,10 +43,10 @@ class Attachments(ApiBase):
         return self.format_and_send_request(data)
 
     def delete(self, key: str):
-        """Delete a attachment in Sage Intacct.
+        """Delete an attachment in Sage Intacct.
 
         Returns:
-            Dict of state of request
+            Dict of state of request response
         """
         data = {
             'delete_supdoc': {

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='sageintacctsdk',
-    version='1.26.1',
+    version='1.26.2',
     author='Ashwin T',
     author_email='ashwin.t@fyle.in',
     description='Python SDK for accessing Sage Intacct APIs',


### PR DESCRIPTION
Currently the delete attachment functionality is missing.
For more details refer: https://github.com/fylein/sageintacct-sdk-py/issues/109

Local testing:
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/015453d5-023b-4ab4-89d1-6472a7813d44" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new attachment deletion capability, enabling users to remove attachments by their identifier.
- **Chores**
	- Updated the package version to 1.26.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->